### PR TITLE
packageVerificationCode 'sha1:' prefix

### DIFF
--- a/plugin/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/plugin/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -202,7 +202,7 @@ public class SpdxDocumentBuilder {
       String sha1 =
           com.google.common.io.Files.asByteSource(dependencyFile).hash(Hashing.sha1()).toString();
       spdxPkgBuilder.setPackageVerificationCode(
-          doc.createPackageVerificationCode(sha1, Collections.emptyList()));
+          doc.createPackageVerificationCode("sha1:" + sha1, Collections.emptyList()));
 
       return Optional.of(spdxPkgBuilder.build());
     }


### PR DESCRIPTION
to make the resulting spdx file slightly more human-readable

See also https://spdx.github.io/spdx-spec/v2.3/package-information/